### PR TITLE
Fix `READONLY_CONFIG_FILE` configurations not being merged

### DIFF
--- a/docker/start.py
+++ b/docker/start.py
@@ -600,13 +600,13 @@ def main():
             merge_config_files(
                 read_only_config_file,
                 OPENGROK_CONFIG_FILE,
-                tmp_out,
+                out_file,
                 jar=OPENGROK_JAR,
                 loglevel=log_level,
             )
 
         if out_file and os.path.getsize(out_file) > 0:
-            shutil.move(tmp_out.name, OPENGROK_CONFIG_FILE)
+            shutil.move(out_file, OPENGROK_CONFIG_FILE)
         else:
             logger.warning(
                 "Failed to merge read-only configuration, "


### PR DESCRIPTION
When `READONLY_CONFIG_FILE` is used, the file name passed to `merge_config_files` is the object as a string which is serialized and written into disk. This always results in a file named `<tempfile._TemporaryFileWrapper object at 0x7fa12bf82350>` on disk instead of the actual name and doesn't actually merge configs.